### PR TITLE
global: addition of missing authors

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,4 +27,7 @@ Authors
 
 ORCID integration for Invenio.
 
-- CERN <info@inveniosoftware.org>
+- Alizee Pace <alizee.pace@gmail.com>
+- Jiri Kuncar <jiri.kuncar@cern.ch>
+- Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>
+- Tibor Simko <tibor.simko@cern.ch>


### PR DESCRIPTION
Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
