### PR TITLE
global: push multiple doc_types

### DIFF
--- a/invenio_orcid/config.py
+++ b/invenio_orcid/config.py
@@ -36,7 +36,7 @@ ORCID_ID_FETCHER = 'invenio_orcid.utils:get_orcid_id'
 ORCID_AUTHORS_SEARCH_CLASS = 'invenio_search:RecordsSearch'
 
 ORCID_RECORDS_PID_TYPE = 'records'
-ORCID_RECORDS_DOC_TYPE = 'records'
+ORCID_RECORDS_DOC_TYPES = {'records', }
 ORCID_RECORDS_PID_FETCHER = 'recid_fetcher'
 
 ORCID_WORK_TYPES = {}

--- a/invenio_orcid/tasks.py
+++ b/invenio_orcid/tasks.py
@@ -101,8 +101,8 @@ def delete_from_orcid(sender, api=None):
 def doc_type_should_be_sent_to_orcid(record):
     """Return ``True`` is a document type should be sent to ORCID."""
     index, doc_type = schema_to_index(record['$schema'])
-    main_doc_type = current_app.config['ORCID_RECORDS_DOC_TYPE']
-    return doc_type == main_doc_type
+    pushable_doc_types = current_app.config['ORCID_RECORDS_DOC_TYPES']
+    return doc_type in pushable_doc_types
 
 
 @shared_task(ignore_result=True)


### PR DESCRIPTION
- Adds support for pushing multiple doc_types to orcid.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
